### PR TITLE
Updated package.json of example to match current version

### DIFF
--- a/adalib-example/package.json
+++ b/adalib-example/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@chakra-ui/react": "^2.5.1",
-    "@dcspark/adalib": "1.2.1",
+    "@dcspark/adalib": "1.3.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",


### PR DESCRIPTION
Without bumping, running the example directly (without linking it to the parent adalib JS) will throw an error due to incompatible calls.